### PR TITLE
Extract exclude rules to separate files, abstract away from Gradle.

### DIFF
--- a/samples/gradle/.mainframerignorelocal
+++ b/samples/gradle/.mainframerignorelocal
@@ -1,0 +1,5 @@
+.gradle
+.idea
+**/.git/
+**/local.properties
+**/build

--- a/samples/gradle/.mainframerignoreremote
+++ b/samples/gradle/.mainframerignoreremote
@@ -1,0 +1,5 @@
+.gradle
+.idea
+**/.git/
+**/local.properties
+**/src/

--- a/samples/gradle/local.properties
+++ b/samples/gradle/local.properties
@@ -1,0 +1,1 @@
+remote_build.machine=sample-remote-build-machine.com


### PR DESCRIPTION
Closes #19.

This allows `mainframer.sh` to support basically *any* build system, see `samples/gradle` for gradle example.