### PR TITLE
Handle non-existing ignore files.

### DIFF
--- a/test/test_ignore_local_files.sh
+++ b/test/test_ignore_local_files.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+# You can run it from any directory.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Execute common pre-setup, include test functions.
+source "$DIR/common.sh"
+
+printTestStarted
+
+# Create several files that should be synced to remote machine.
+mkdir "$BUILD_DIR/src"
+touch "$BUILD_DIR/src/file1.txt"
+touch "$BUILD_DIR/src/file2.txt"
+touch "$BUILD_DIR/src/file3.txt"
+touch "$BUILD_DIR/src/file4.txt"
+
+# Add a rule to ignore two local files.
+echo "src/file2.txt" > "$LOCAL_IGNORE_FILE"
+echo "src/file3.txt" >> "$LOCAL_IGNORE_FILE"
+
+# Run mainframer.sh that noops.
+bash "$BUILD_DIR"/mainframer.sh 'echo noop'
+
+# Make sure all files except ignored exist on remote machine.
+fileMustExistOnRemoteMachine "src/file1.txt" "(sync problem)"
+fileMustExistOnRemoteMachine "src/file4.txt" "(sync problem)"
+
+# Make sure ignored files do not exist on remote machine.
+fileMustNotExistOnRemoteMachine "src/file2.txt" "(local ignore problem)"
+fileMustNotExistOnRemoteMachine "src/file3.txt" "(local ignore problem)"
+
+printTestEnded

--- a/test/test_ignore_remote_files.sh
+++ b/test/test_ignore_remote_files.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+# You can run it from any directory.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Execute common pre-setup, include test functions.
+source "$DIR/common.sh"
+
+printTestStarted
+
+# Add a rule to ignore two remote files.
+echo "build/file2.txt" > "$REMOTE_IGNORE_FILE"
+echo "build/file3.txt" >> "$REMOTE_IGNORE_FILE"
+
+# Run mainframer.sh that creates 4 files on remote machine.
+bash "$BUILD_DIR"/mainframer.sh 'mkdir build && touch build/file1.txt && touch build/file2.txt && touch build/file3.txt && touch build/file4.txt'
+
+# Make sure all files except ignored exist on local machine.
+fileMustExistOnLocalMachine "build/file1.txt" "(sync problem)"
+fileMustExistOnLocalMachine "build/file4.txt" "(sync problem)"
+
+# Make sure ignored files do not exist on local machine.
+fileMustNotExistOnLocalMachine "build/file2.txt" "(remote ignore problem)"
+fileMustNotExistOnLocalMachine "build/file3.txt" "(remote ignore problem)"
+
+printTestEnded

--- a/test/test_no_rules_for_ignore_local_files.sh
+++ b/test/test_no_rules_for_ignore_local_files.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# You can run it from any directory.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Execute common pre-setup, include test functions.
+source "$DIR/common.sh"
+
+printTestStarted
+
+# Make sure local ignore rules do not exist. 
+rm -f "$LOCAL_IGNORE_FILE"
+
+# Run mainframer.sh that noops to make sure that it does not exit with error.
+bash "$BUILD_DIR"/mainframer.sh 'echo noop'
+
+printTestEnded

--- a/test/test_no_rules_for_ignore_remote_files.sh
+++ b/test/test_no_rules_for_ignore_remote_files.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# You can run it from any directory.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Execute common pre-setup, include test functions.
+source "$DIR/common.sh"
+
+printTestStarted
+
+# Make sure remote ignore rules do not exist. 
+rm -f "$REMOTE_IGNORE_FILE"
+
+# Run mainframer.sh that noops to make sure that it does not exit with error.
+bash "$BUILD_DIR"/mainframer.sh 'echo noop'
+
+printTestEnded


### PR DESCRIPTION
`rsync` exits with error code if file passed to `--ignore-from` does not exist.

This PR handles that and also refactors `mainframer.sh` into bunch of functions for easier understanding.