### PR TITLE
Use .mainframer/personalconfig instead of local.properties.

### DIFF
--- a/mainframer.sh
+++ b/mainframer.sh
@@ -11,17 +11,23 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_DIR=$DIR
 PROJECT_DIR_NAME="$( basename "$PROJECT_DIR")"
 MAINFRAMER_DIR="$PROJECT_DIR/.mainframer"
+PERSONAL_CONFIG_FILE="$MAINFRAMER_DIR/personalconfig"
 IGNORE_LOCAL_FILE="$MAINFRAMER_DIR/localignore"
 IGNORE_REMOTE_FILE="$MAINFRAMER_DIR/remoteignore"
 
 function property {
-    grep "^${1}=" "$MAINFRAMER_DIR"/local.properties | cut -d'=' -f2
+    grep "^${1}=" "$PERSONAL_CONFIG_FILE" | cut -d'=' -f2
 }
 
-# Read config variables from local.properties.
-REMOTE_BUILD_MACHINE=$(property 'remote_build.machine')
-LOCAL_COMPRESS_LEVEL=$(property 'remote_build.local_gzip_level')
-REMOTE_COMPRESS_LEVEL=$(property 'remote_build.remote_gzip_level')
+# Config properties.
+REMOTE_MACHINE_PROPERTY="remote_machine"
+LOCAL_COMPRESS_LEVEL_PROPERTY="local_compression_level"
+REMOTE_COMPRESS_LEVEL_PROPERTY="remote_compression_level"
+
+# Read config properties.
+REMOTE_BUILD_MACHINE=$(property "$REMOTE_MACHINE_PROPERTY")
+LOCAL_COMPRESS_LEVEL=$(property "$LOCAL_COMPRESS_LEVEL_PROPERTY")
+REMOTE_COMPRESS_LEVEL=$(property "$REMOTE_COMPRESS_LEVEL_PROPERTY")
 
 if [ -z "$LOCAL_COMPRESS_LEVEL" ]; then
 	LOCAL_COMPRESS_LEVEL=1
@@ -32,7 +38,7 @@ if [ -z "$REMOTE_COMPRESS_LEVEL" ]; then
 fi
 
 if [ -z "$REMOTE_BUILD_MACHINE" ]; then
-	echo "Please specify remote build machine in local.properties"
+	echo "Please specify \"$REMOTE_MACHINE_PROPERTY\" in $PERSONAL_CONFIG_FILE"
 	exit 1
 fi
 

--- a/test/common.sh
+++ b/test/common.sh
@@ -17,6 +17,7 @@ PRIVATE_REMOTE_BUILD_DIR="~/$PRIVATE_BUILD_DIR_NAME"
 
 # Should be used by tests.
 BUILD_DIR="$DIR/$PRIVATE_BUILD_DIR_NAME"
+PERSONAL_CONFIG_FILE="$BUILD_DIR/.mainframer/personalconfig"
 LOCAL_IGNORE_FILE="$BUILD_DIR/.mainframer/localignore"
 REMOTE_IGNORE_FILE="$BUILD_DIR/.mainframer/remoteignore"
 
@@ -101,5 +102,5 @@ mkdir -p "$BUILD_DIR/.mainframer"
 # Copy mainframer.sh into build directory.
 cp "$DIR/../mainframer.sh" "$BUILD_DIR/"
 
-# Create local.properties that sets remote build machine for the test.
-echo "remote_build.machine=$PRIVATE_TEST_REMOTE_MACHINE" > "$BUILD_DIR/.mainframer/local.properties"
+# Create config that sets remote build machine for the test.
+echo "remote_machine=$PRIVATE_TEST_REMOTE_MACHINE" > "$PERSONAL_CONFIG_FILE"

--- a/test/test_no_personal_config.sh
+++ b/test/test_no_personal_config.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# You can run it from any directory.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Execute common pre-setup, include test functions.
+source "$DIR/common.sh"
+
+printTestStarted
+
+# Make sure personal config does not exist. 
+rm -f "$PERSONAL_CONFIG_FILE"
+
+set +e
+
+# Run mainframer.sh that noops to make sure that it exits with error.
+bash "$BUILD_DIR"/mainframer.sh 'echo noop'
+
+if [ "$?" == "0" ]; then
+	set -e
+	echo "Should have failed because personal config does not exist."
+	exit 1
+fi
+
+set -e
+
+printTestEnded

--- a/test/test_no_remote_machine_in_personal_config.sh
+++ b/test/test_no_remote_machine_in_personal_config.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# You can run it from any directory.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Execute common pre-setup, include test functions.
+source "$DIR/common.sh"
+
+printTestStarted
+
+# Make sure personal config is empty. 
+echo "" > "$PERSONAL_CONFIG_FILE"
+
+set +e
+
+# Run mainframer.sh that noops to make sure that it exits with error.
+bash "$BUILD_DIR"/mainframer.sh 'echo noop'
+
+if [ "$?" == "0" ]; then
+	set -e
+	echo "Should have failed because personal config does not contain remote machine property."
+	exit 1
+fi
+
+set -e
+
+printTestEnded


### PR DESCRIPTION
Closes #50.

In future we can add `.mainframer/teamconfig` that usually meant to be commited to VCS while `.mainframer/personalconfig` is meant to be ignored from VCS.