### PR TITLE
Fix remote_setup_script documentation

### DIFF
--- a/recipes/SETUP_REMOTE_MACHINE.md
+++ b/recipes/SETUP_REMOTE_MACHINE.md
@@ -43,9 +43,9 @@ pushd "/home/$NEW_USER"
 
 # Setup ssh access.
 mkdir -p .ssh
-chmod +urwx,go= .ssh
+chmod u+rwx,go= .ssh
 echo "$AUTHORIZED_SSH_KEY" > .ssh/authorized_keys
-chmod +urw,go= .ssh/authorized_keys
+chmod u+rw,go= .ssh/authorized_keys
 
 # Example of adding env variable to user's ~/.bashrc.
 mv .bashrc .bashrc_original


### PR DESCRIPTION
Hey,

when trying to put this script into a file it wasn't running.
I checked the documentation and found out that the `+` needs to be after the `u` in order to make this script work.

Cheers
