### PR TITLE
Format time to output minutes, hours and seconds

### DIFF
--- a/mainframer.sh
+++ b/mainframer.sh
@@ -34,9 +34,6 @@ REMOTE_IGNORE_FILE="$CONFIG_DIR/remoteignore"
  HOURS_TAG="hours"
  MINUTES_TAG="minutes"
  SECONDS_TAG="seconds"
- HOURS_FORMAT="%02d"
- MINUTES_FORMAT="%02d"
- SECONDS_FORMAT="%02d"
 
 function read_config_property {
     grep "^${1}=" "$CONFIG_FILE" | cut -d'=' -f2
@@ -85,24 +82,25 @@ function convertSecondsToTime {
     #Find out the time format and correct string.
     if [ "$h" -eq "1" ]; then
         HOURS_TAG="hour"
-        HOURS_FORMAT="%01d"
     fi
     if [ "$m" -eq "1" ]; then
         MINUTES_TAG="minute"
-        MINUTES_FORMAT="%01d"
     fi
     if [ "$s" -eq "1" ]; then
         SECONDS_TAG="second"
-        SECONDS_FORMAT="%01d"
     fi
 
      #Check if hour is 0, so it doesn't need to be shown.
-     if [ "$h" -eq "0" ]; then
-        # shellcheck disable=SC2059
-        printf "$MINUTES_FORMAT $MINUTES_TAG $SECONDS_FORMAT $SECONDS_TAG\n" ${m} ${s}
+     if [ "$h" -eq "0" ] && [ "$m" -eq "0" ]; then
+        printf "%d $SECONDS_TAG\n" ${s}
+     elif [ "$h" -eq "0" ]; then
+        printf "%d $MINUTES_TAG %d $SECONDS_TAG\n" ${m} ${s}
+     elif [ "$m" -eq "0" ]; then
+        printf "%d $HOURS_TAG %d $SECONDS_TAG\n" ${h} ${s}
+     elif [ "$s" -eq "0" ]; then
+        printf "%d $HOURS_TAG %d $MINUTES_TAG\n" ${h} ${m}
      else
-        # shellcheck disable=SC2059
-        printf "$HOURS_FORMAT $HOURS_TAG $MINUTES_FORMAT $MINUTES_TAG $SECONDS_FORMAT $SECONDS_TAG\n" ${h} ${m} ${s}
+        printf "%d $HOURS_TAG %d $MINUTES_TAG %d $SECONDS_TAG\n" ${h} ${m} ${s}
       fi
 }
 

--- a/mainframer.sh
+++ b/mainframer.sh
@@ -90,9 +90,9 @@ function formatTime {
         SECONDS_TAG="second"
     fi
 
-    (( $h > 0 )) && printf "%d $HOURS_TAG " ${h}
-    (( $m > 0 )) && printf "%d $MINUTES_TAG " ${m}
-    (( $s > 0 )) && printf "%d $SECONDS_TAG \n" ${s}
+    (( h > 0 )) && printf "%d $HOURS_TAG " ${h}
+    (( m > 0 )) && printf "%d $MINUTES_TAG " ${m}
+    (( s > 0 )) && printf "%d $SECONDS_TAG \n" ${s}
 }
 
 function syncBeforeRemoteCommand {

--- a/mainframer.sh
+++ b/mainframer.sh
@@ -90,7 +90,7 @@ function convertSecondsToTime {
         SECONDS_TAG="second"
     fi
 
-     #Check if hour is 0, so it doesn't need to be shown.
+     #See if we can emit one of the time units, because it's 0.
      if [ "$h" -eq "0" ] && [ "$m" -eq "0" ]; then
         printf "%d $SECONDS_TAG\n" ${s}
      elif [ "$h" -eq "0" ]; then

--- a/mainframer.sh
+++ b/mainframer.sh
@@ -31,10 +31,6 @@ COMMON_IGNORE_FILE="$CONFIG_DIR/ignore"
 LOCAL_IGNORE_FILE="$CONFIG_DIR/localignore"
 REMOTE_IGNORE_FILE="$CONFIG_DIR/remoteignore"
 
-HOURS_TAG="hours"
-MINUTES_TAG="minutes"
-SECONDS_TAG="seconds"
-
 function read_config_property {
     grep "^${1}=" "$CONFIG_FILE" | cut -d'=' -f2
 }
@@ -75,24 +71,19 @@ if [ -z "$REMOTE_COMMAND" ]; then
 fi
 
 function formatTime {
-    ((h=${1}/3600))
-    ((m=(${1}%3600)/60))
-    ((s=${1}%60))
+    local time=$1
 
-    #Find out the time format and correct string.
-    if [ "$h" -eq "1" ]; then
-        HOURS_TAG="hour"
-    fi
-    if [ "$m" -eq "1" ]; then
-        MINUTES_TAG="minute"
-    fi
-    if [ "$s" -eq "1" ]; then
-        SECONDS_TAG="second"
-    fi
+    local hours=$((time/3600))
+    local minutes=$(((time % 3600) / 60))
+    local seconds=$((time % 60))
 
-    (( h > 0 )) && printf "%d $HOURS_TAG " ${h}
-    (( m > 0 )) && printf "%d $MINUTES_TAG " ${m}
-    (( s > 0 )) && printf "%d $SECONDS_TAG \n" ${s}
+    if [ "$hours" -eq "1" ]; then HOURS_LABEL="hour"; else HOURS_LABEL="hours"; fi
+    if [ "$minutes" -eq "1" ]; then MINUTES_LABEL="minute"; else MINUTES_LABEL="minutes"; fi
+    if [ "$seconds" -eq "1" ]; then SECONDS_LABEL="second"; else SECONDS_LABEL="seconds"; fi
+
+    (( hours > 0 )) && printf "%d $HOURS_LABEL " ${hours}
+    (( minutes > 0 )) && printf "%d $MINUTES_LABEL " ${minutes}
+    (( seconds > 0 )) && printf "%d $SECONDS_LABEL \n" ${seconds}
 }
 
 function syncBeforeRemoteCommand {

--- a/mainframer.sh
+++ b/mainframer.sh
@@ -70,6 +70,13 @@ if [ -z "$REMOTE_COMMAND" ]; then
 	exit 1
 fi
 
+function convertSecondsToTime {
+ ((h=${1}/3600))
+ ((m=(${1}%3600)/60))
+ ((s=${1}%60))
+ printf "%02d:%02d:%02d\n" $h $m $s
+}
+
 function syncBeforeRemoteCommand {
 	echo "Sync local → remote machine..."
 	startTime="$(date +%s)"
@@ -89,7 +96,7 @@ function syncBeforeRemoteCommand {
 	eval "$COMMAND"
 
 	endTime="$(date +%s)"
-	echo "Sync done: took $((endTime-startTime)) seconds."
+	echo "Sync done: took $(convertsecs $((endTime-startTime)))"
 	echo ""
 }
 
@@ -110,9 +117,9 @@ function executeRemoteCommand {
 	duration="$((endTime-startTime))"
 
 	if [ "$REMOTE_COMMAND_SUCCESSFUL" == "true" ]; then
-		echo "Execution done: took $duration seconds."
+		echo "Execution done: took $(convertsecs $duration)"
 	else
-		echo "Execution failed: took $duration seconds."
+		echo "Execution failed: took $(convertsecs $duration)"
 	fi
 
 	echo ""
@@ -136,7 +143,7 @@ function syncAfterRemoteCommand {
 	eval "$COMMAND"
 
 	endTime="$(date +%s)"
-	echo "Sync done: took $((endTime-startTime)) seconds."
+	echo "Sync done: took $(convertsecs $((endTime-startTime)))"
 }
 
 pushd "$PROJECT_DIR" > /dev/null
@@ -153,8 +160,8 @@ echo ""
 DURATION="$((FINISH_TIME-START_TIME))"
 
 if [ "$REMOTE_COMMAND_SUCCESSFUL" == "true" ]; then
-	echo "Success: took $DURATION seconds."
+	echo "Success: took $(convertsecs $DURATION)"
 else
-	echo "Failure: took $DURATION seconds."
+	echo "Failure: took $(convertsecs $DURATION)"
 	exit 1
 fi

--- a/mainframer.sh
+++ b/mainframer.sh
@@ -78,30 +78,32 @@ if [ -z "$REMOTE_COMMAND" ]; then
 fi
 
 function convertSecondsToTime {
-((h=${1}/3600))
-((m=(${1}%3600)/60))
-((s=${1}%60))
+    ((h=${1}/3600))
+    ((m=(${1}%3600)/60))
+    ((s=${1}%60))
 
-#Find out the time format and correct string.
-if [ "$h" -eq "1" ]; then
-    HOURS_TAG="hour"
-    HOURS_FORMAT="%01d"
-fi
-if [ "$m" -eq "1" ]; then
-    MINUTES_TAG="minute"
-    MINUTES_FORMAT="%01d"
-fi
-if [ "$s" -eq "1" ]; then
-    SECONDS_TAG="second"
-    SECONDS_FORMAT="%01d"
-fi
+    #Find out the time format and correct string.
+    if [ "$h" -eq "1" ]; then
+        HOURS_TAG="hour"
+        HOURS_FORMAT="%01d"
+    fi
+    if [ "$m" -eq "1" ]; then
+        MINUTES_TAG="minute"
+        MINUTES_FORMAT="%01d"
+    fi
+    if [ "$s" -eq "1" ]; then
+        SECONDS_TAG="second"
+        SECONDS_FORMAT="%01d"
+    fi
 
- #Check if hour is 0, so it doesn't need to be shown.
- if [ "$h" -eq "0" ]; then
-    printf "$MINUTES_FORMAT $MINUTES_TAG $SECONDS_FORMAT $SECONDS_TAG\n" ${m} ${s}
- else
-    printf "$HOURS_FORMAT $HOURS_TAG $MINUTES_FORMAT $MINUTES_TAG $SECONDS_FORMAT $SECONDS_TAG\n" ${h} ${m} ${s}
-  fi
+     #Check if hour is 0, so it doesn't need to be shown.
+     if [ "$h" -eq "0" ]; then
+        # shellcheck disable=SC2059
+        printf "$MINUTES_FORMAT $MINUTES_TAG $SECONDS_FORMAT $SECONDS_TAG\n" ${m} ${s}
+     else
+        # shellcheck disable=SC2059
+        printf "$HOURS_FORMAT $HOURS_TAG $MINUTES_FORMAT $MINUTES_TAG $SECONDS_FORMAT $SECONDS_TAG\n" ${h} ${m} ${s}
+      fi
 }
 
 function syncBeforeRemoteCommand {

--- a/mainframer.sh
+++ b/mainframer.sh
@@ -73,7 +73,7 @@ fi
 function formatTime {
     local time=$1
 
-    local hours=$((time/3600))
+    local hours=$((time / 3600))
     local minutes=$(((time % 3600) / 60))
     local seconds=$((time % 60))
 
@@ -83,7 +83,7 @@ function formatTime {
 
     (( hours > 0 )) && printf "%d $HOURS_LABEL " ${hours}
     (( minutes > 0 )) && printf "%d $MINUTES_LABEL " ${minutes}
-    (( seconds > 0 )) && printf "%d $SECONDS_LABEL \n" ${seconds}
+    (( seconds >= 0 )) && printf "%d $SECONDS_LABEL \n" ${seconds}
 }
 
 function syncBeforeRemoteCommand {


### PR DESCRIPTION
Just to bring #121 a bit forward I implemented this little converter function to output formatted time.

In the logs it will now look like this (hh:mm:ss):

`Sync done: took 00:00:26`

@ming13 @artem-zinnatullin 

