### PR TITLE
Add integration for AWS EC2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Tool that allows you to move build process from a local machine to a remote one.
 
-Remote machine ought to be much faster than a laptop. 
+Remote machine ought to be much faster than a laptop.
 With `mainframer` you can free up your local machine for better things —
 like editing source code in your IDE without lags and
 freezes, being able to actually _use_ your computer when the build is happening.
@@ -35,6 +35,7 @@ We have quite a bunch of samples showing off some practical applications.
 ## Setup
 
 * [Remote machine](docs/SETUP_REMOTE.md)
+* [AWS EC2 integration](docs/SETUP_AWS_EC2.md)
 * [Local machine](docs/SETUP_LOCAL.md)
 * [Configuration](docs/CONFIGURATION.md)
 
@@ -44,7 +45,7 @@ We have quite a bunch of samples showing off some practical applications.
 
 ## 3rd-party IntelliJ Mainframer Plugin
 
-Guys from [@elpassion](https://github.com/elpassion) maintain [IntelliJ Plugin for Mainframer](https://github.com/elpassion/mainframer-intellij-plugin) that makes integration of Mainframer with any IntelliJ project better. 
+Guys from [@elpassion](https://github.com/elpassion) maintain [IntelliJ Plugin for Mainframer](https://github.com/elpassion/mainframer-intellij-plugin) that makes integration of Mainframer with any IntelliJ project better.
 
 We highly recommend the plugin if you use IntelliJ with Mainframer!
 

--- a/docs/SETUP_AWS_EC2.md
+++ b/docs/SETUP_AWS_EC2.md
@@ -6,7 +6,7 @@
 
 ## Setup on Local Machine
 You can use a AWS EC2 instance as remote build machine. Simple define `ec2_instance_id`
-in the `config` with the instance id to use. Install and setup AWS CLI using:
+in the `config` (see ["local setup"](SETUP_LOCAL.md)) with the instance id to use. Install and setup AWS CLI using:
 
 ```
 brew install awscli
@@ -30,7 +30,7 @@ Perform following steps in AWS:
 2. Select Amazon Linux (SSD Volume Type)
 3. Select a instance type. It's recommended to use a t2.* instance as they are able to provide higher performance in bursts which is usually the case when developing and compiling every now and then. Using a t2.large instance is a good point of start, you then can either go up and down the instance types based on your needs (you also can change the instance later).
 4. Click `Review and Launch` and then `Launch`
-5. Create a new key pair and store the `.pem` file. Store this file in `~/.ssh/` and use it as `{SSH_KEY_NAME}` in ["the local setup"](SETUP_LOCAL.md)
+5. Create a new key pair. Store the `.pem` file downloaded at `~/.ssh/` and use it as `{SSH_KEY_NAME}` in ["the local setup"](SETUP_LOCAL.md)
 6. In the list of instances, select the newly created instance
 7. Select the `Monitoring` tab and then `Create Alarm`
 8. Uncheck `Send a notification to` and check `Take action`and `Stop this instance`

--- a/docs/SETUP_AWS_EC2.md
+++ b/docs/SETUP_AWS_EC2.md
@@ -41,4 +41,4 @@ Perform following steps in AWS to create a new EC2 instance with a static public
 13. Select your instance EC2 instance in `Instance`
 14. Select a private IP in `Private IP`
 15. Click `Associate`
-16. Copy the IP address and use it ad `{REMOTE_MACHINE_IP_OR_HOSTNAME}` in [the local setup](SETUP_LOCAL.md)
+16. Copy the IP address and use it as `{REMOTE_MACHINE_IP_OR_HOSTNAME}` in [the local setup](SETUP_LOCAL.md)

--- a/docs/SETUP_AWS_EC2.md
+++ b/docs/SETUP_AWS_EC2.md
@@ -1,0 +1,44 @@
+# AWS EC2 Setup (Optional)
+
+## Dependencies
+
+* AWS CLI
+
+## Setup on Local Machine
+You can use a AWS EC2 instance as remote build machine. Simple define `ec2_instance_id`
+in the `config` with the instance id to use. Install and setup AWS CLI using:
+
+```
+brew install awscli
+aws configure
+```
+
+Mainframer will use your gloabl AWS configuration, so make sure to use the correct region
+and secret key for your EC2 instance when configuring AWS CLI.
+
+## Recommended Setup on AWS
+It is strongly recommended to use a Cloud Watch alarm to automatically shutdown the
+EC2 instance when not in use. Mainframer will automatically start the instance when
+a build is started but the EC2 instance is not running.
+
+*Disclaimer*: Running a t2.large instance will cost you roughly $ 0.10 per hour. Look [here](https://aws.amazon.com/en/ec2/pricing/) for details.
+
+Perform following steps in AWS:
+
+0. Create a new AWS account if not done yet and add a new payment method
+1. Go to `Services` -> `EC2` -> `Instances` -> `Launch Instance`
+2. Select Amazon Linux (SSD Volume Type)
+3. Select a instance type. It's recommended to use a t2.* instance as they are able to provide higher performance in bursts which is usually the case when developing and compiling every now and then. Using a t2.large instance is a good point of start, you then can either go up and down the instance types based on your needs (you also can change the instance later).
+4. Click `Review and Launch` and then `Launch`
+5. Create a new key pair and store the `.pem` file. Store this file in `~/.ssh/` and use it as `{SSH_KEY_NAME}` in ["the local setup"](SETUP_LOCAL.md)
+6. In the list of instances, select the newly created instance
+7. Select the `Monitoring` tab and then `Create Alarm`
+8. Uncheck `Send a notification to` and check `Take action`and `Stop this instance`
+9. Select `Whenever Maximum of CPU Ultilization Is <= 5 Percent For at least 6 consecutive period(s) of 5 Minutes`
+10. Click `Create Alarm`
+11. Go to `Elastic IPs` and select `Allocate new address`, then `Allocate` and then `Close`
+12. Right-click on the address in the list and click `Associate address`
+13. Select your instance EC2 instance in `Instance`
+14. Select a private IP in `Private IP`
+15. Click `Associate`
+16. Copy the IP address and use it ad `{REMOTE_MACHINE_IP_OR_HOSTNAME}` in ["the local setup"](SETUP_LOCAL.md)

--- a/docs/SETUP_AWS_EC2.md
+++ b/docs/SETUP_AWS_EC2.md
@@ -21,7 +21,7 @@ It is strongly recommended to use a Cloud Watch alarm to automatically shutdown 
 EC2 instance when not in use. Mainframer will automatically start the instance when
 a build is started but the EC2 instance is not running.
 
-*Disclaimer*: Running a t2.large instance will cost you roughly $ 0.10 per hour. Look [here](https://aws.amazon.com/en/ec2/pricing/) for details.
+*Disclaimer*: Running a t2.large instance will cost you roughly $0.10 per hour. Look [here](https://aws.amazon.com/en/ec2/pricing/) for details.
 
 Perform following steps in AWS to create a new EC2 instance with a static public IPv4 address which automatically shuts down if not used for 30 minutes:
 

--- a/docs/SETUP_AWS_EC2.md
+++ b/docs/SETUP_AWS_EC2.md
@@ -23,7 +23,7 @@ a build is started but the EC2 instance is not running.
 
 *Disclaimer*: Running a t2.large instance will cost you roughly $ 0.10 per hour. Look [here](https://aws.amazon.com/en/ec2/pricing/) for details.
 
-Perform following steps in AWS:
+Perform following steps in AWS to create a new EC2 instance with a static public IPv4 address which automatically shuts down if not used for 30 minutes:
 
 0. Create a new AWS account if not done yet and add a new payment method
 1. Go to `Services` -> `EC2` -> `Instances` -> `Launch Instance`

--- a/docs/SETUP_AWS_EC2.md
+++ b/docs/SETUP_AWS_EC2.md
@@ -6,7 +6,7 @@
 
 ## Setup on Local Machine
 You can use a AWS EC2 instance as remote build machine. Simple define `ec2_instance_id`
-in the `config` (see ["local setup"](SETUP_LOCAL.md)) with the instance id to use. Install and setup AWS CLI using:
+in the `config` (see [local setup](SETUP_LOCAL.md)) with the instance id to use. Install and setup AWS CLI using:
 
 ```
 brew install awscli
@@ -30,7 +30,7 @@ Perform following steps in AWS:
 2. Select Amazon Linux (SSD Volume Type)
 3. Select a instance type. It's recommended to use a t2.* instance as they are able to provide higher performance in bursts which is usually the case when developing and compiling every now and then. Using a t2.large instance is a good point of start, you then can either go up and down the instance types based on your needs (you also can change the instance later).
 4. Click `Review and Launch` and then `Launch`
-5. Create a new key pair. Store the `.pem` file downloaded at `~/.ssh/` and use it as `{SSH_KEY_NAME}` in ["the local setup"](SETUP_LOCAL.md)
+5. Create a new key pair. Store the `.pem` file downloaded at `~/.ssh/` and use it as `{SSH_KEY_NAME}` in [the local setup](SETUP_LOCAL.md)
 6. In the list of instances, select the newly created instance
 7. Select the `Monitoring` tab and then `Create Alarm`
 8. Uncheck `Send a notification to` and check `Take action`and `Stop this instance`
@@ -41,4 +41,4 @@ Perform following steps in AWS:
 13. Select your instance EC2 instance in `Instance`
 14. Select a private IP in `Private IP`
 15. Click `Associate`
-16. Copy the IP address and use it ad `{REMOTE_MACHINE_IP_OR_HOSTNAME}` in ["the local setup"](SETUP_LOCAL.md)
+16. Copy the IP address and use it ad `{REMOTE_MACHINE_IP_OR_HOSTNAME}` in [the local setup](SETUP_LOCAL.md)

--- a/mainframer
+++ b/mainframer
@@ -38,6 +38,7 @@ function readConfigProperty {
 REMOTE_MACHINE_CONFIG_PROPERTY="remote_machine"
 LOCAL_COMPRESS_LEVEL_CONFIG_PROPERTY="local_compression_level"
 REMOTE_COMPRESS_LEVEL_CONFIG_PROPERTY="remote_compression_level"
+EC2_INSTANCE_ID_PROPERTY="ec2_instance_id"
 
 if [ ! -f "$CONFIG_FILE" ]; then
 	echo "Please create and fill $CONFIG_FILE."
@@ -47,6 +48,7 @@ fi
 REMOTE_MACHINE=$(readConfigProperty "$REMOTE_MACHINE_CONFIG_PROPERTY")
 LOCAL_COMPRESS_LEVEL=$(readConfigProperty "$LOCAL_COMPRESS_LEVEL_CONFIG_PROPERTY")
 REMOTE_COMPRESS_LEVEL=$(readConfigProperty "$REMOTE_COMPRESS_LEVEL_CONFIG_PROPERTY")
+EC2_INSTANCE_ID=$(readConfigProperty "$EC2_INSTANCE_ID_PROPERTY")
 
 if [ -z "$REMOTE_MACHINE" ]; then
 	echo "Please specify \"$REMOTE_MACHINE_CONFIG_PROPERTY\" in $CONFIG_FILE."
@@ -60,7 +62,6 @@ fi
 if [ -z "$REMOTE_COMPRESS_LEVEL" ]; then
 	REMOTE_COMPRESS_LEVEL=1
 fi
-
 
 REMOTE_COMMAND="$*"
 REMOTE_COMMAND_SUCCESSFUL="false"
@@ -84,6 +85,42 @@ function formatTime {
 	(( hours > 0 )) && printf "%d $HOURS_LABEL " ${hours}
 	(( minutes > 0 )) && printf "%d $MINUTES_LABEL " ${minutes}
 	(( seconds >= 0 )) && printf "%d $SECONDS_LABEL" ${seconds}
+}
+
+function startAwsEc2 {
+	# Start AWS instance
+	echo "Checking state of EC2 instance $EC2_INSTANCE_ID..."
+	startTime="$(date +%s)"
+
+	EC2_STATE=`aws ec2 start-instances --instance-ids $EC2_INSTANCE_ID`
+	if [[ "$EC2_STATE" =~ "pending" ]]; then
+		# Wait for instance to have state "running"
+		printf "Starting EC2 instance $EC2_INSTANCE_ID..."
+		while [[ "$EC2_STATE" != *running* ]]; do
+			EC2_STATE=`aws ec2 describe-instances --instance-ids $EC2_INSTANCE_ID`
+			sleep .1
+			printf "."
+		done
+		printf "\n"
+
+		# Wait for instance to be usable
+		printf "Waiting for EC2 instance $EC2_INSTANCE_ID to be ready..."
+		while [[ 1 ]]; do
+			if ssh $REMOTE_MACHINE "echo test" &> /dev/null; then
+				break
+			else
+				printf '.'
+			fi
+			sleep .5
+		done
+		printf "\n"
+
+		endTime="$(date +%s)"
+		echo "Startup done: took $(formatTime $((endTime-startTime)))."
+	else
+		endTime="$(date +%s)"
+		echo "Check done: took $(formatTime $((endTime-startTime)))."
+	fi
 }
 
 function syncBeforeRemoteCommand {
@@ -156,6 +193,10 @@ function syncAfterRemoteCommand {
 }
 
 pushd "$PROJECT_DIR" > /dev/null
+
+if [[ "$EC2_INSTANCE_ID" != "" ]]; then
+	startAwsEc2
+fi
 
 syncBeforeRemoteCommand
 executeRemoteCommand

--- a/mainframer
+++ b/mainframer
@@ -92,21 +92,21 @@ function startAwsEc2 {
 	echo "Checking state of EC2 instance $EC2_INSTANCE_ID..."
 	startTime="$(date +%s)"
 
-	EC2_STATE=`aws ec2 start-instances --instance-ids $EC2_INSTANCE_ID`
+	EC2_STATE=$(aws ec2 start-instances --instance-ids "$EC2_INSTANCE_ID")
 	if [[ "$EC2_STATE" =~ "pending" ]]; then
 		# Wait for instance to have state "running"
-		printf "Starting EC2 instance $EC2_INSTANCE_ID..."
+		printf "Starting EC2 instance %s..." "$EC2_INSTANCE_ID"
 		while [[ "$EC2_STATE" != *running* ]]; do
-			EC2_STATE=`aws ec2 describe-instances --instance-ids $EC2_INSTANCE_ID`
+			EC2_STATE=$(aws ec2 describe-instances --instance-ids "$EC2_INSTANCE_ID")
 			sleep .1
 			printf "."
 		done
 		printf "\n"
 
 		# Wait for instance to be usable
-		printf "Waiting for EC2 instance $EC2_INSTANCE_ID to be ready..."
-		while [[ 1 ]]; do
-			if ssh $REMOTE_MACHINE "echo test" &> /dev/null; then
+		printf "Waiting for EC2 instance %s to be ready..." "$EC2_INSTANCE_ID"
+		while true; do
+			if ssh "$REMOTE_MACHINE" "echo test" &> /dev/null; then
 				break
 			else
 				printf '.'


### PR DESCRIPTION
We used a custom version of mainframer 1.1.0 since a couple of months. I integrated our changes into the main project. 

Mainframer can now use a AWS EC2 instance as remote build machine and is able to start the instance automatically if the instance is stopped.