### PR TITLE
added a default configuration file

### DIFF
--- a/mainframer
+++ b/mainframer
@@ -26,6 +26,11 @@ PROJECT_DIR_NAME="$( basename "$PROJECT_DIR" )"
 PROJECT_DIR_ON_REMOTE_MACHINE="~/mainframer/$PROJECT_DIR_NAME"
 
 CONFIG_DIR="$PROJECT_DIR/.mainframer"
+
+if [ ! -d $CONFIG_DIR ]; then
+	CONFIG_DIR="$HOME/.mainframer"
+fi;
+
 CONFIG_FILE="$CONFIG_DIR/config"
 COMMON_IGNORE_FILE="$CONFIG_DIR/ignore"
 LOCAL_IGNORE_FILE="$CONFIG_DIR/localignore"


### PR DESCRIPTION
Thats really useful for my scenario, I work with a lot of different Android projects, and it is quite boring to configure mainframer to all of them.
This also might be beneficial when having different mainframer configuration between devs on the same project.

The only issue that I found so far is that sometimes I run mainframer in the wrong dir, and then it starts synchronise the full folder hehehe.