### PR TITLE
Isolate running build from changes in project files.

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -5,13 +5,22 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_DIR="$DIR/.."
 
-cp "$PROJECT_DIR/ci/docker/Dockerfile" "$PROJECT_DIR"
-cp "$PROJECT_DIR/ci/docker/.dockerignore" "$PROJECT_DIR"
+# Create separate build dir and copy project to it.
+# That allows us modify original project files without affecting running build which is helpful for local development.
+BUILD_DIR="$DIR/tmp"
 
-# Remove Dockerfile from root directory when build exits either successfully or with error code.
-trap 'rm "$PROJECT_DIR/Dockerfile" && rm "$PROJECT_DIR/.dockerignore"' EXIT
+# Clean previous build state.
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
 
-pushd "$PROJECT_DIR"
+# Copy project to build dir.
+cp -R "$PROJECT_DIR" "$BUILD_DIR"
+
+# Put Docker files to root of build dir to use build dir as working dir for Docker.
+cp "$BUILD_DIR/ci/docker/Dockerfile" "$BUILD_DIR"
+cp "$BUILD_DIR/ci/docker/.dockerignore" "$BUILD_DIR"
+
+pusd "$BUILD_DIR" > /dev/null
 
 # Files created in mounted volume by container should have same owner as host machine user to prevent chmod problems.
 USER_ID=`id -u $USER`
@@ -47,4 +56,4 @@ docker run \
 mainframer:latest \
 bash -c "$BUILD_COMMAND"
 
-popd
+popd > /dev/null

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -6,21 +6,21 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_DIR="$DIR/.."
 
 # Create separate build dir and copy project to it.
-# That allows us modify original project files without affecting running build which is helpful for local development.
-BUILD_DIR="$DIR/tmp"
+# That allows us safely modify project files during the build which is helpful for local development.
+BUILD_DIR="$PROJECT_DIR/build"
 
 # Clean previous build state.
 rm -rf "$BUILD_DIR"
 mkdir -p "$BUILD_DIR"
 
-# Copy project to build dir.
-cp -R "$PROJECT_DIR" "$BUILD_DIR"
+# Copy project to the build dir.
+rsync --archive --exclude "/.idea" --exclude "/build" "$PROJECT_DIR/" "$BUILD_DIR/"
 
 # Put Docker files to root of build dir to use build dir as working dir for Docker.
 cp "$BUILD_DIR/ci/docker/Dockerfile" "$BUILD_DIR"
 cp "$BUILD_DIR/ci/docker/.dockerignore" "$BUILD_DIR"
 
-pusd "$BUILD_DIR" > /dev/null
+pushd "$BUILD_DIR" > /dev/null
 
 # Files created in mounted volume by container should have same owner as host machine user to prevent chmod problems.
 USER_ID=`id -u $USER`


### PR DESCRIPTION
Running `ci/build.sh` takes about a 1 minute and 20 seconds and if you modify project files during the build - you directly affect it because we mount project directory to a Docker container.

This PR isolates build from project directory by copying project to a `build` folder, so now you can safely modify project while build is running.

I'll be optimizing build time as well, but I think it's important to have both isolated and fast builds. 

`build/` is already in `.gitignore` just btw