### PR TITLE
Compile with warnings as errors

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -17,6 +17,8 @@ echo "Running shellcheck against all .sh files in the project..."
 
 # shellcheck disable=SC2016
 docker run \
+--interactive \
+--tty \
 --rm \
 --volume "$(pwd)":/project:ro \
 --entrypoint sh \
@@ -67,6 +69,8 @@ BUILD_COMMAND+="/opt/project/test/test.sh --run-samples &&"
 BUILD_COMMAND+="cd /opt/project && cargo build --release && mkdir -p artifacts && mv target/release/mainframer artifacts/mainframer-$TRAVIS_TAG-$(uname -s)"
 
 docker run \
+--interactive \
+--tty \
 --rm \
 --volume "$(pwd)":/opt/project \
 --env LOCAL_USER_ID="$USER_ID" \

--- a/test/build_and_unit_tests.sh
+++ b/test/build_and_unit_tests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+export RUSTFLAGS="--deny warnings"
+
 echo "Building debug version of Mainframer..."
 cargo build
 


### PR DESCRIPTION
Closes #193.

Final part of making our build stricter — treating compile warnings as errors.

The change also includes docker arguments to propagate interactive output, thus get colors of warnings/errors locally and on CI (as well as CTRL+C support and other signals propagated through interactive mode).

Tested by adding unused variable:

```console
Building debug version of Mainframer...
   Compiling mainframer v3.0.0-dev (/opt/project)
error: unused variable: `x`
  --> src/main.rs:30:9
   |
30 |     let x = 1;
   |         ^ help: consider using `_x` instead
   |
   = note: `-D unused-variables` implied by `-D warnings`

error: aborting due to previous error

error: Could not compile `mainframer`.

To learn more, run the command again with --verbose.

Test run FAILED, 1 test(s).
To log each step: export DEBUG_MODE_FOR_ALL_TESTS=true
```