### PR TITLE
Remove android env var from build script

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -56,7 +56,6 @@ BUILD_COMMAND+="chmod u+rw,go= ~/.ssh/known_hosts && "
 
 # Configure environment variables in ~/.bashrc for current and ssh sessions.
 BUILD_COMMAND+="mv ~/.bashrc ~/.bashrc_original && "
-BUILD_COMMAND+="echo -e 'export ANDROID_HOME=/opt/android-sdk-linux\\n' >> ~/.bashrc && "
 BUILD_COMMAND+="echo -e 'source \"\$HOME/.cargo/env\"\\n' >> ~/.bashrc && "
 BUILD_COMMAND+="cat ~/.bashrc_original >> ~/.bashrc && "
 BUILD_COMMAND+="rm ~/.bashrc_original && "


### PR DESCRIPTION
It's a leftover since we've stopped running integration samples on CI in #251.